### PR TITLE
Change scheme values

### DIFF
--- a/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/additional-document-reference.ftl
+++ b/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/additional-document-reference.ftl
@@ -1,6 +1,6 @@
     <#list otrosDocumentosTributariosRelacionados as item>
     <cac:AdditionalDocumentReference>
         <cbc:ID>${item.serieNumero}</cbc:ID>
-        <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT: Identificador de documento relacionado" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo12">${item.tipoDocumento.code}</cbc:DocumentTypeCode>
+        <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Documento relacionado" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo12">${item.tipoDocumento.code}</cbc:DocumentTypeCode>
     </cac:AdditionalDocumentReference>
     </#list>

--- a/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/customer.ftl
+++ b/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/customer.ftl
@@ -3,7 +3,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <cac:PartyIdentification>
-                <cbc:ID schemeID="${cliente.tipoDocumentoIdentidad.code}" schemeAgencyName="PE:SUNAT" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">${cliente.numeroDocumentoIdentidad}</cbc:ID>
+                <cbc:ID schemeID="${cliente.tipoDocumentoIdentidad.code}" schemeAgencyName="PE:SUNAT" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">${cliente.numeroDocumentoIdentidad}</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName><![CDATA[${cliente.nombre}]]></cbc:RegistrationName>

--- a/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/despatch-document-reference.ftl
+++ b/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/despatch-document-reference.ftl
@@ -1,6 +1,6 @@
     <#list guiasRemisionRelacionadas as item>
     <cac:DespatchDocumentReference>
         <cbc:ID>${item.serieNumero}</cbc:ID>
-        <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de guía relacionada" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">${item.tipoDocumento.code}</cbc:DocumentTypeCode>
+        <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Guía relacionada" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">${item.tipoDocumento.code}</cbc:DocumentTypeCode>
     </cac:DespatchDocumentReference>
     </#list>

--- a/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/document-line.ftl
+++ b/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/document-line.ftl
@@ -2,7 +2,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="${moneda}">${item.precioDeReferencia.precio}</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">${item.precioDeReferencia.tipoPrecio.code}</cbc:PriceTypeCode>
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">${item.precioDeReferencia.tipoPrecio.code}</cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
         </cac:PricingReference>
 <#--        <#list item.cargos as cargo>-->
@@ -46,7 +46,7 @@
                 <cac:TaxCategory>
                     <cbc:ID schemeAgencyName="United Nations Economic Commission for Europe" schemeID="UN/ECE 5305" schemeName="Tax Category Identifier">${item.impuestos.igv.categoria.categoria}</cbc:ID>
                     <cbc:Percent>${item.impuestos.igv.porcentaje}</cbc:Percent>
-                    <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="SUNAT:Codigo de Tipo de Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">${item.impuestos.igv.tipo.code}</cbc:TaxExemptionReasonCode>
+                    <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">${item.impuestos.igv.tipo.code}</cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
                         <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="UN/ECE 5153" schemeName="Codigo de tributos">${item.impuestos.igv.categoria.code}</cbc:ID>
                         <cbc:Name>${item.impuestos.igv.categoria.nombre}</cbc:Name>

--- a/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/note/invoice-reference.ftl
+++ b/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/note/invoice-reference.ftl
@@ -11,6 +11,6 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>${serieNumeroComprobanteAfectado}</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">${tipoDocumentoComprobanteAfectado.code}</cbc:DocumentTypeCode>
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">${tipoDocumentoComprobanteAfectado.code}</cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
     </cac:BillingReference>

--- a/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/supplier.ftl
+++ b/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/common/supplier.ftl
@@ -3,7 +3,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <cac:PartyIdentification>
-                <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">${proveedor.ruc}</cbc:ID>
+                <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">${proveedor.ruc}</cbc:ID>
             </cac:PartyIdentification>
             <#if proveedor.nombreComercial??>
             <cac:PartyName>

--- a/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/despatch-advice.ftl
+++ b/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/despatch-advice.ftl
@@ -26,13 +26,13 @@
     <#if guiaRemisionDadaDeBaja??>
     <cac:OrderReference>
         <cbc:ID>${guiaRemisionDadaDeBaja.serieNumero}</cbc:ID>
-        <cbc:OrderTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">${guiaRemisionDadaDeBaja.tipoDocumento.code}</cbc:OrderTypeCode>
+        <cbc:OrderTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">${guiaRemisionDadaDeBaja.tipoDocumento.code}</cbc:OrderTypeCode>
     </cac:OrderReference>
     </#if>
     <#if documentoAdicionalRelacionado??>
     <cac:AdditionalDocumentReference>
         <cbc:ID>${documentoAdicionalRelacionado.serieNumero}</cbc:ID>
-        <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de documento relacionado" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo21">${documentoAdicionalRelacionado.tipoDocumento.code}</cbc:DocumentTypeCode>
+        <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Documento relacionado" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo21">${documentoAdicionalRelacionado.tipoDocumento.code}</cbc:DocumentTypeCode>
     </cac:AdditionalDocumentReference>
     </#if>
     <#include "../signature.ftl">

--- a/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/invoice.ftl
+++ b/src/main/resources/io/github/project/openubl/xmlbuilderlib/templates/standard/invoice.ftl
@@ -7,7 +7,7 @@
     <#include "common/ubl-extensions.ftl">
     <#include "common/general-data.ftl">
 <#--    <#if fechaVencimiento??><cbc:DueDate>${fechaVencimiento}</cbc:DueDate></#if>-->
-    <cbc:InvoiceTypeCode listID="0101" listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">${tipoInvoice.code}</cbc:InvoiceTypeCode>
+    <cbc:InvoiceTypeCode listID="0101" listAgencyName="PE:SUNAT" listName="Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">${tipoInvoice.code}</cbc:InvoiceTypeCode>
 <#--    <#include "./common/legends.ftl">-->
     <cbc:DocumentCurrencyCode listID="ISO 4217 Alpha" listAgencyName="United Nations Economic Commission for Europe" listName="Currency">${moneda}</cbc:DocumentCurrencyCode>
 <#--    <#if orderCompra??>-->
@@ -20,7 +20,7 @@
 <#--    <#list anticipos as item>-->
 <#--    <cac:AdditionalDocumentReference>-->
 <#--        <cbc:ID>${item.serieNumero}</cbc:ID>-->
-<#--        <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT: Identificador de documento relacionado" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo12">${item.tipoDocumento.code}</cbc:DocumentTypeCode>-->
+<#--        <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Documento relacionado" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo12">${item.tipoDocumento.code}</cbc:DocumentTypeCode>-->
 <#--        <cbc:DocumentStatusCode listName="Anticipo" listAgencyName="PE:SUNAT">${item?index + 1}</cbc:DocumentStatusCode>-->
 <#--        <cac:IssuerParty>-->
 <#--            <cac:PartyIdentification>-->

--- a/src/test/java/io/github/project/openubl/xmlbuilderlib/integrationtest/ubl/invoice/InvoiceTest.java
+++ b/src/test/java/io/github/project/openubl/xmlbuilderlib/integrationtest/ubl/invoice/InvoiceTest.java
@@ -200,7 +200,7 @@ public class InvoiceTest extends AbstractUBLTest {
                                 .withDepartamento("Ayacucho")
                                 .withProvincia("Huamanga")
                                 .withDistrito("Jesus Nazareno")
-                                .withCodigoLocal("010101")
+                                .withCodigoLocal("05003")
                                 .withUrbanizacion("000000")
                                 .withDireccion("Jr. Las piedras 123")
                                 .withCodigoPais("PE")

--- a/src/test/java/io/github/project/openubl/xmlbuilderlib/integrationtest/ubl/invoice/InvoiceTest.java
+++ b/src/test/java/io/github/project/openubl/xmlbuilderlib/integrationtest/ubl/invoice/InvoiceTest.java
@@ -200,7 +200,7 @@ public class InvoiceTest extends AbstractUBLTest {
                                 .withDepartamento("Ayacucho")
                                 .withProvincia("Huamanga")
                                 .withDistrito("Jesus Nazareno")
-                                .withCodigoLocal("05003")
+                                .withCodigoLocal("010101")
                                 .withUrbanizacion("000000")
                                 .withDireccion("Jr. Las piedras 123")
                                 .withCodigoPais("PE")

--- a/src/test/resources/xml/cases/proveedorsincodigopostal/CreditNote.xml
+++ b/src/test/resources/xml/cases/proveedorsincodigopostal/CreditNote.xml
@@ -32,7 +32,7 @@
   <cac:BillingReference>
     <cac:InvoiceDocumentReference>
       <cbc:ID>F009-9</cbc:ID>
-      <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01</cbc:DocumentTypeCode>
+      <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01</cbc:DocumentTypeCode>
     </cac:InvoiceDocumentReference>
   </cac:BillingReference>
   <cac:Signature>
@@ -54,7 +54,7 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">22222222222</cbc:ID>
+        <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">22222222222</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName><![CDATA[Proveedor]]></cbc:RegistrationName>
@@ -64,7 +64,7 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">33333333333</cbc:ID>
+        <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">33333333333</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName><![CDATA[Cliente]]></cbc:RegistrationName>
@@ -98,7 +98,7 @@
     <cac:PricingReference>
       <cac:AlternativeConditionPrice>
         <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-        <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01</cbc:PriceTypeCode>
+        <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01</cbc:PriceTypeCode>
       </cac:AlternativeConditionPrice>
     </cac:PricingReference>
     <cac:TaxTotal>
@@ -109,7 +109,7 @@
         <cac:TaxCategory>
           <cbc:ID schemeAgencyName="United Nations Economic Commission for Europe" schemeID="UN/ECE 5305" schemeName="Tax Category Identifier">S</cbc:ID>
           <cbc:Percent>18</cbc:Percent>
-          <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="SUNAT:Codigo de Tipo de Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10</cbc:TaxExemptionReasonCode>
+          <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10</cbc:TaxExemptionReasonCode>
           <cac:TaxScheme>
             <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="UN/ECE 5153" schemeName="Codigo de tributos">1000</cbc:ID>
             <cbc:Name>IGV</cbc:Name>

--- a/src/test/resources/xml/cases/proveedorsincodigopostal/DebitNote.xml
+++ b/src/test/resources/xml/cases/proveedorsincodigopostal/DebitNote.xml
@@ -32,7 +32,7 @@
   <cac:BillingReference>
     <cac:InvoiceDocumentReference>
       <cbc:ID>F009-9</cbc:ID>
-      <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01</cbc:DocumentTypeCode>
+      <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01</cbc:DocumentTypeCode>
     </cac:InvoiceDocumentReference>
   </cac:BillingReference>
   <cac:Signature>
@@ -54,7 +54,7 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">22222222222</cbc:ID>
+        <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">22222222222</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName><![CDATA[Proveedor]]></cbc:RegistrationName>
@@ -64,7 +64,7 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">33333333333</cbc:ID>
+        <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">33333333333</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName><![CDATA[Cliente]]></cbc:RegistrationName>
@@ -98,7 +98,7 @@
     <cac:PricingReference>
       <cac:AlternativeConditionPrice>
         <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-        <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01</cbc:PriceTypeCode>
+        <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01</cbc:PriceTypeCode>
       </cac:AlternativeConditionPrice>
     </cac:PricingReference>
     <cac:TaxTotal>
@@ -109,7 +109,7 @@
         <cac:TaxCategory>
           <cbc:ID schemeAgencyName="United Nations Economic Commission for Europe" schemeID="UN/ECE 5305" schemeName="Tax Category Identifier">S</cbc:ID>
           <cbc:Percent>18</cbc:Percent>
-          <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="SUNAT:Codigo de Tipo de Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10</cbc:TaxExemptionReasonCode>
+          <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10</cbc:TaxExemptionReasonCode>
           <cac:TaxScheme>
             <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="UN/ECE 5153" schemeName="Codigo de tributos">1000</cbc:ID>
             <cbc:Name>IGV</cbc:Name>

--- a/src/test/resources/xml/cases/proveedorsincodigopostal/Invoice.xml
+++ b/src/test/resources/xml/cases/proveedorsincodigopostal/Invoice.xml
@@ -20,7 +20,7 @@
   <cbc:ID>F001-1</cbc:ID>
   <cbc:IssueDate>2019-02-01</cbc:IssueDate>
   <cbc:IssueTime>18:30:00</cbc:IssueTime>
-  <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01</cbc:InvoiceTypeCode>
+  <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha" listName="Currency">PEN</cbc:DocumentCurrencyCode>
   <cbc:LineCountNumeric>1</cbc:LineCountNumeric>
   <cac:Signature>
@@ -42,7 +42,7 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">22222222222</cbc:ID>
+        <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">22222222222</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Proveedor</cbc:RegistrationName>
@@ -52,7 +52,7 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">33333333333</cbc:ID>
+        <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">33333333333</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Cliente</cbc:RegistrationName>
@@ -86,7 +86,7 @@
     <cac:PricingReference>
       <cac:AlternativeConditionPrice>
         <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-        <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01</cbc:PriceTypeCode>
+        <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01</cbc:PriceTypeCode>
       </cac:AlternativeConditionPrice>
     </cac:PricingReference>
     <cac:TaxTotal>
@@ -97,7 +97,7 @@
         <cac:TaxCategory>
           <cbc:ID schemeAgencyName="United Nations Economic Commission for Europe" schemeID="UN/ECE 5305" schemeName="Tax Category Identifier">S</cbc:ID>
           <cbc:Percent>18</cbc:Percent>
-          <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="SUNAT:Codigo de Tipo de Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10</cbc:TaxExemptionReasonCode>
+          <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10</cbc:TaxExemptionReasonCode>
           <cac:TaxScheme>
             <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="UN/ECE 5153" schemeName="Codigo de tributos">1000</cbc:ID>
             <cbc:Name>IGV</cbc:Name>

--- a/src/test/resources/xml/creditnote/mindata/MinData_DNI.xml
+++ b/src/test/resources/xml/creditnote/mindata/MinData_DNI.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>B001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="1" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/creditnote/mindata/MinData_DecDiplomatica.xml
+++ b/src/test/resources/xml/creditnote/mindata/MinData_DecDiplomatica.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>B001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="A" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/creditnote/mindata/MinData_DocTribNoDomSinRuc.xml
+++ b/src/test/resources/xml/creditnote/mindata/MinData_DocTribNoDomSinRuc.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>B001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/creditnote/mindata/MinData_Extranjeria.xml
+++ b/src/test/resources/xml/creditnote/mindata/MinData_Extranjeria.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>B001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="4" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/creditnote/mindata/MinData_Pasaporte.xml
+++ b/src/test/resources/xml/creditnote/mindata/MinData_Pasaporte.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>B001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="7" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/creditnote/mindata/MinData_RUC.xml
+++ b/src/test/resources/xml/creditnote/mindata/MinData_RUC.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>F001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/creditnote/mindata/MinData_UsePrecioUnitarioOPrecioConIgv.xml
+++ b/src/test/resources/xml/creditnote/mindata/MinData_UsePrecioUnitarioOPrecioConIgv.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>F001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/creditnote/mindata/MinData_UsePrecioUnitarioOPrecioConIgvAndCantidadThreeDecimals.xml
+++ b/src/test/resources/xml/creditnote/mindata/MinData_UsePrecioUnitarioOPrecioConIgvAndCantidadThreeDecimals.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>F001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/creditnote/tiponota/descuentoPorItem.xml
+++ b/src/test/resources/xml/creditnote/tiponota/descuentoPorItem.xml
@@ -36,7 +36,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>F001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -74,7 +74,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -115,7 +115,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -131,7 +131,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -160,7 +160,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -176,7 +176,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/debitnote/mindata/MinData_DNI.xml
+++ b/src/test/resources/xml/debitnote/mindata/MinData_DNI.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>B001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="1" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/debitnote/mindata/MinData_DecDiplomatica.xml
+++ b/src/test/resources/xml/debitnote/mindata/MinData_DecDiplomatica.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>B001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="A" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/debitnote/mindata/MinData_DocTribNoDomSinRuc.xml
+++ b/src/test/resources/xml/debitnote/mindata/MinData_DocTribNoDomSinRuc.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>B001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/debitnote/mindata/MinData_Extranjeria.xml
+++ b/src/test/resources/xml/debitnote/mindata/MinData_Extranjeria.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>B001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="4" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/debitnote/mindata/MinData_Pasaporte.xml
+++ b/src/test/resources/xml/debitnote/mindata/MinData_Pasaporte.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>B001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="7" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/debitnote/mindata/MinData_RUC.xml
+++ b/src/test/resources/xml/debitnote/mindata/MinData_RUC.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>F001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/debitnote/mindata/MinData_UsePrecioUnitarioOPrecioConIgv.xml
+++ b/src/test/resources/xml/debitnote/mindata/MinData_UsePrecioUnitarioOPrecioConIgv.xml
@@ -31,7 +31,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>F001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01</cbc:DocumentTypeCode>
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01</cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
     </cac:BillingReference>
     <cac:Signature>
@@ -53,7 +53,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <cac:PartyIdentification>
-                <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912</cbc:ID>
+                <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName><![CDATA[Softgreen S.A.C.]]></cbc:RegistrationName>
@@ -63,7 +63,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <cac:PartyIdentification>
-                <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121</cbc:ID>
+                <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName><![CDATA[Carlos Feria]]></cbc:RegistrationName>
@@ -97,7 +97,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01</cbc:PriceTypeCode>
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01</cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
         </cac:PricingReference>
         <cac:TaxTotal>
@@ -108,7 +108,7 @@
                 <cac:TaxCategory>
                     <cbc:ID schemeAgencyName="United Nations Economic Commission for Europe" schemeID="UN/ECE 5305" schemeName="Tax Category Identifier">S</cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
-                    <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="SUNAT:Codigo de Tipo de Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10</cbc:TaxExemptionReasonCode>
+                    <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10</cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
                         <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="UN/ECE 5153" schemeName="Codigo de tributos">1000</cbc:ID>
                         <cbc:Name>IGV</cbc:Name>
@@ -131,7 +131,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01</cbc:PriceTypeCode>
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01</cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
         </cac:PricingReference>
         <cac:TaxTotal>
@@ -142,7 +142,7 @@
                 <cac:TaxCategory>
                     <cbc:ID schemeAgencyName="United Nations Economic Commission for Europe" schemeID="UN/ECE 5305" schemeName="Tax Category Identifier">S</cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
-                    <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="SUNAT:Codigo de Tipo de Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10</cbc:TaxExemptionReasonCode>
+                    <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT" listName="Afectacion del IGV" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10</cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
                         <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="UN/ECE 5153" schemeName="Codigo de tributos">1000</cbc:ID>
                         <cbc:Name>IGV</cbc:Name>

--- a/src/test/resources/xml/debitnote/mindata/MinData_UsePrecioUnitarioOPrecioConIgvAndCantidadThreeDecimals.xml
+++ b/src/test/resources/xml/debitnote/mindata/MinData_UsePrecioUnitarioOPrecioConIgvAndCantidadThreeDecimals.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>F001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/debitnote/tiponota/descuentoPorItem.xml
+++ b/src/test/resources/xml/debitnote/tiponota/descuentoPorItem.xml
@@ -35,7 +35,7 @@
     <cac:BillingReference>
         <cac:InvoiceDocumentReference>
             <cbc:ID>F001-1</cbc:ID>
-            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+            <cbc:DocumentTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                                   listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
             </cbc:DocumentTypeCode>
         </cac:InvoiceDocumentReference>
@@ -60,7 +60,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -73,7 +73,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -114,7 +114,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -130,7 +130,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -159,7 +159,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -175,7 +175,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/customClienteDireccionAndContacto.xml
+++ b/src/test/resources/xml/invoice/customClienteDireccionAndContacto.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -58,7 +58,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <cac:PartyIdentification>
-                <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121</cbc:ID>
+                <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>Carlos Feria</cbc:RegistrationName>
@@ -115,7 +115,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -131,7 +131,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -160,7 +160,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -176,7 +176,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/customFechaEmision.xml
+++ b/src/test/resources/xml/invoice/customFechaEmision.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-01-06</cbc:IssueDate>
     <cbc:IssueTime>00:00:00</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/customFirmante.xml
+++ b/src/test/resources/xml/invoice/customFirmante.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/customProveedorDireccionAndContacto.xml
+++ b/src/test/resources/xml/invoice/customProveedorDireccionAndContacto.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -54,7 +54,7 @@
                 <cbc:RegistrationName>Softgreen S.A.C.</cbc:RegistrationName>
                 <cac:RegistrationAddress>
                     <cbc:ID>050101</cbc:ID>
-                    <cbc:AddressTypeCode>010101</cbc:AddressTypeCode>
+                    <cbc:AddressTypeCode>05003</cbc:AddressTypeCode>
                     <cbc:CitySubdivisionName>000000</cbc:CitySubdivisionName>
                     <cbc:CityName>Huamanga</cbc:CityName>
                     <cbc:CountrySubentity>Ayacucho</cbc:CountrySubentity>
@@ -76,7 +76,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <cac:PartyIdentification>
-                <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="SUNAT:Identificador de Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121</cbc:ID>
+                <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT" schemeName="Documento de Identidad" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>Carlos Feria</cbc:RegistrationName>
@@ -115,7 +115,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -131,7 +131,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -160,7 +160,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -176,7 +176,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/customProveedorDireccionAndContacto.xml
+++ b/src/test/resources/xml/invoice/customProveedorDireccionAndContacto.xml
@@ -54,7 +54,7 @@
                 <cbc:RegistrationName>Softgreen S.A.C.</cbc:RegistrationName>
                 <cac:RegistrationAddress>
                     <cbc:ID>050101</cbc:ID>
-                    <cbc:AddressTypeCode>05003</cbc:AddressTypeCode>
+                    <cbc:AddressTypeCode>010101</cbc:AddressTypeCode>
                     <cbc:CitySubdivisionName>000000</cbc:CitySubdivisionName>
                     <cbc:CityName>Huamanga</cbc:CityName>
                     <cbc:CountrySubentity>Ayacucho</cbc:CountrySubentity>

--- a/src/test/resources/xml/invoice/customUnidadMedida.xml
+++ b/src/test/resources/xml/invoice/customUnidadMedida.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/icb.xml
+++ b/src/test/resources/xml/invoice/icb.xml
@@ -22,7 +22,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listID="0101" listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listID="0101" listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listID="ISO 4217 Alpha" listAgencyName="United Nations Economic Commission for Europe"
@@ -48,7 +48,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -116,7 +116,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -132,7 +132,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -175,7 +175,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -191,7 +191,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/mindata/MinData_DNI.xml
+++ b/src/test/resources/xml/invoice/mindata/MinData_DNI.xml
@@ -22,7 +22,7 @@
     <cbc:ID>B001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -48,7 +48,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="1"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -102,7 +102,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -118,7 +118,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -147,7 +147,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -163,7 +163,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/mindata/MinData_DecDiplomatica.xml
+++ b/src/test/resources/xml/invoice/mindata/MinData_DecDiplomatica.xml
@@ -22,7 +22,7 @@
     <cbc:ID>B001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -48,7 +48,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="A"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -102,7 +102,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -118,7 +118,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -147,7 +147,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -163,7 +163,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/mindata/MinData_DocTribNoDomSinRuc.xml
+++ b/src/test/resources/xml/invoice/mindata/MinData_DocTribNoDomSinRuc.xml
@@ -22,7 +22,7 @@
     <cbc:ID>B001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -48,7 +48,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="0"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -102,7 +102,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -118,7 +118,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -147,7 +147,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -163,7 +163,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/mindata/MinData_Extranjeria.xml
+++ b/src/test/resources/xml/invoice/mindata/MinData_Extranjeria.xml
@@ -22,7 +22,7 @@
     <cbc:ID>B001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -48,7 +48,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="4"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -102,7 +102,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -118,7 +118,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -147,7 +147,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -163,7 +163,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/mindata/MinData_Pasaporte.xml
+++ b/src/test/resources/xml/invoice/mindata/MinData_Pasaporte.xml
@@ -22,7 +22,7 @@
     <cbc:ID>B001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">03
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -48,7 +48,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="7"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -102,7 +102,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -118,7 +118,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -147,7 +147,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -163,7 +163,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/mindata/MinData_RUC.xml
+++ b/src/test/resources/xml/invoice/mindata/MinData_RUC.xml
@@ -22,7 +22,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -48,7 +48,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -102,7 +102,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -118,7 +118,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -147,7 +147,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -163,7 +163,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/mindata/MinData_UsePrecioUnitarioOPrecioConIgv.xml
+++ b/src/test/resources/xml/invoice/mindata/MinData_UsePrecioUnitarioOPrecioConIgv.xml
@@ -22,7 +22,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -48,7 +48,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -102,7 +102,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -118,7 +118,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -147,7 +147,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -163,7 +163,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/mindata/MinData_UsePrecioUnitarioOPrecioConIgvAndCantidadThreeDecimals.xml
+++ b/src/test/resources/xml/invoice/mindata/MinData_UsePrecioUnitarioOPrecioConIgvAndCantidadThreeDecimals.xml
@@ -22,7 +22,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -48,7 +48,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -102,7 +102,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -118,7 +118,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -147,7 +147,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -163,7 +163,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/exoneradoOperacionOnerosa.xml
+++ b/src/test/resources/xml/invoice/tipoigv/exoneradoOperacionOnerosa.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">20
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">20
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/exoneradoTransferenciaGratuita.xml
+++ b/src/test/resources/xml/invoice/tipoigv/exoneradoTransferenciaGratuita.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">21
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">21
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/exportacion.xml
+++ b/src/test/resources/xml/invoice/tipoigv/exportacion.xml
@@ -22,7 +22,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listID="0101" listAgencyName="PE:SUNAT" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listID="0101" listAgencyName="PE:SUNAT" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listID="ISO 4217 Alpha" listAgencyName="United Nations Economic Commission for Europe"
@@ -48,7 +48,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="6" schemeAgencyName="PE:SUNAT"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -87,7 +87,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -103,7 +103,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">40
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -132,7 +132,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -148,7 +148,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">40
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/gravadoBonificaciones.xml
+++ b/src/test/resources/xml/invoice/tipoigv/gravadoBonificaciones.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">15
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">15
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/gravadoIVAP.xml
+++ b/src/test/resources/xml/invoice/tipoigv/gravadoIVAP.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">104</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>4</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">17
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">104</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>4</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">17
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/gravadoOnerosa.xml
+++ b/src/test/resources/xml/invoice/tipoigv/gravadoOnerosa.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/gravadoRetiro.xml
+++ b/src/test/resources/xml/invoice/tipoigv/gravadoRetiro.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">13
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">13
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/gravadoRetiroPorDonacion.xml
+++ b/src/test/resources/xml/invoice/tipoigv/gravadoRetiroPorDonacion.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">12
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">12
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/gravadoRetiroPorEntregaATrabajadores.xml
+++ b/src/test/resources/xml/invoice/tipoigv/gravadoRetiroPorEntregaATrabajadores.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">16
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">16
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/gravadoRetiroPorPremio.xml
+++ b/src/test/resources/xml/invoice/tipoigv/gravadoRetiroPorPremio.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">11
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">11
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/gravadoRetiroPorPublicidad.xml
+++ b/src/test/resources/xml/invoice/tipoigv/gravadoRetiroPorPublicidad.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">14
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">14
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/inafectoOperacionOnerosa.xml
+++ b/src/test/resources/xml/invoice/tipoigv/inafectoOperacionOnerosa.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">30
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">30
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/inafectoPorMuestrasMedicas.xml
+++ b/src/test/resources/xml/invoice/tipoigv/inafectoPorMuestrasMedicas.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">33
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">33
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/inafectoRetiro.xml
+++ b/src/test/resources/xml/invoice/tipoigv/inafectoRetiro.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">32
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">32
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/inafectoRetiroPorBonificacion.xml
+++ b/src/test/resources/xml/invoice/tipoigv/inafectoRetiroPorBonificacion.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">31
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">31
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/inafectoRetiroPorConvenioColectivo.xml
+++ b/src/test/resources/xml/invoice/tipoigv/inafectoRetiroPorConvenioColectivo.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">34
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">34
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/inafectoRetiroPorPremio.xml
+++ b/src/test/resources/xml/invoice/tipoigv/inafectoRetiroPorPremio.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">35
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">35
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice/tipoigv/inafectoRetiroPorPublicidad.xml
+++ b/src/test/resources/xml/invoice/tipoigv/inafectoRetiroPorPublicidad.xml
@@ -20,7 +20,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -46,7 +46,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -116,7 +116,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">36
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -145,7 +145,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">100</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">02
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -161,7 +161,7 @@
                     </cbc:ID>
                     <cbc:Percent>0</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">36
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>

--- a/src/test/resources/xml/invoice_specialCharacters.xml
+++ b/src/test/resources/xml/invoice_specialCharacters.xml
@@ -22,7 +22,7 @@
     <cbc:ID>F001-1</cbc:ID>
     <cbc:IssueDate>2019-12-24</cbc:IssueDate>
     <cbc:IssueTime>20:30:59</cbc:IssueTime>
-    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="SUNAT:Identificador de Tipo de Documento"
+    <cbc:InvoiceTypeCode listAgencyName="PE:SUNAT" listID="0101" listName="Tipo de Documento"
                          listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo01">01
     </cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode listAgencyName="United Nations Economic Commission for Europe" listID="ISO 4217 Alpha"
@@ -48,7 +48,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12345678912
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -61,7 +61,7 @@
         <cac:Party>
             <cac:PartyIdentification>
                 <cbc:ID schemeAgencyName="PE:SUNAT" schemeID="6"
-                        schemeName="SUNAT:Identificador de Documento de Identidad"
+                        schemeName="Documento de Identidad"
                         schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">12121212121
                 </cbc:ID>
             </cac:PartyIdentification>
@@ -102,7 +102,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -118,7 +118,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>
@@ -147,7 +147,7 @@
         <cac:PricingReference>
             <cac:AlternativeConditionPrice>
                 <cbc:PriceAmount currencyID="PEN">118</cbc:PriceAmount>
-                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="SUNAT:Indicador de Tipo de Precio"
+                <cbc:PriceTypeCode listAgencyName="PE:SUNAT" listName="Tipo de Precio"
                                    listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo16">01
                 </cbc:PriceTypeCode>
             </cac:AlternativeConditionPrice>
@@ -163,7 +163,7 @@
                     </cbc:ID>
                     <cbc:Percent>18</cbc:Percent>
                     <cbc:TaxExemptionReasonCode listAgencyName="PE:SUNAT"
-                                                listName="SUNAT:Codigo de Tipo de Afectacion del IGV"
+                                                listName="Afectacion del IGV"
                                                 listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo07">10
                     </cbc:TaxExemptionReasonCode>
                     <cac:TaxScheme>


### PR DESCRIPTION
Since 2020 the regex for scheme changed so changing it in our templates makes sense too.

For instance:
- `listName="SUNAT: Identificador de documento relacionado"` became `listName="Documento relacionado"`

> Note: these changes only make disappear observations from SUNAT but it does not mean that the XMLs itself are invalid. This is just an elegant enhancement.